### PR TITLE
Fix the import paths in the styles-ie.scss.

### DIFF
--- a/docroot/profiles/campsite/themes/campsite_theme/sass/style-ie.scss
+++ b/docroot/profiles/campsite/themes/campsite_theme/sass/style-ie.scss
@@ -7,8 +7,8 @@ $IE-support: true;
 
 // Import bootstrap variables and mixins.
 // Bootstrap is compiled from bootstrap.scss
-@import "../lib/sass_bootstrap/vendor/assets/stylesheets/bootstrap/variables";
-@import "../lib/sass_bootstrap/vendor/assets/stylesheets/bootstrap/mixins";
+@import "../../../../../sites/all/libraries/bootstrap_sass/assets/stylesheets/bootstrap/variables";
+@import "../../../../../sites/all/libraries/bootstrap_sass/assets/stylesheets/bootstrap/mixins";
 
 
 //


### PR DESCRIPTION
The `compass compile` throws errors because of the wring import path.
